### PR TITLE
Updating UAI Federated credenitals and pipeline

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -27,7 +27,6 @@ jobs:
         working-directory: ./cluster-deployment
     name: Terraform Plan
     runs-on: ubuntu-latest
-    environment: dev
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/github-deployment/main.tf
+++ b/github-deployment/main.tf
@@ -45,6 +45,16 @@ module "gh_federated_credential" {
   issuer_url                         = local.github_issuer_url
 }
 
+module "gh_federated_credential-pr" {
+  source                             = "../modules/federated-identity-credential"
+  federated_identity_credential_name = "${var.github_organization_target}-${var.github_repository}-pr"
+  rg_name                            = module.identity-resource-group.name
+  user_assigned_identity_id          = module.gh_usi.user_assinged_identity_id
+  subject                            = "repo:${var.github_organization_target}/${var.github_repository}:pull_request"
+  audience_name                      = local.default_audience_name
+  issuer_url                         = local.github_issuer_url
+}
+
 module "tfstate_role_assignment" {
   source       = "../modules/role-assignment"
   principal_id = module.gh_usi.user_assinged_identity_principal_id


### PR DESCRIPTION
This pull request includes changes to the deployment infrastructure and adds a new module for GitHub federated credentials in the Terraform configuration. The most important changes are detailed below.

### Deployment Infrastructure:

* [`.github/workflows/deploy-infra.yml`](diffhunk://#diff-4c19f571e78aef48c8dbd1f55a643094ff0688cbdafd9babb7962cf7443a5c2dL30): Removed the `environment: dev` line from the `Terraform Plan` job configuration.

### Terraform Configuration:

* [`github-deployment/main.tf`](diffhunk://#diff-7dd976f7823dda82252b697131521a93692cb961a6d471ede8c9e34ccf1c8e5fR48-R57): Added a new module `gh_federated_credential-pr` for federated identity credentials specific to pull requests. This includes parameters such as `federated_identity_credential_name`, `rg_name`, `user_assigned_identity_id`, `subject`, `audience_name`, and `issuer_url`.