### PR TITLE
Adding Dapr extension to cluster

### DIFF
--- a/cluster-deployment/main.tf
+++ b/cluster-deployment/main.tf
@@ -89,6 +89,13 @@ module "aks" {
   aks_name       = var.aks_name
 }
 
+module "dapr-extension" {
+  source         = "../modules/aks-extension"
+  extension_type = var.dapr_extension_type
+  cluster_id     = module.aks.aks_id
+  ext_name       = var.dapr_extension_name
+}
+
 module "am-dce" {
   source   = "../modules/azure-monitor-dce"
   dce_name = substr("MSProm-${module.resource-group.location}-${var.aks_name}", 0, min(44, length("MSProm-${module.resource-group.location}-${var.aks_name}")))

--- a/cluster-deployment/providers.tf
+++ b/cluster-deployment/providers.tf
@@ -28,8 +28,7 @@ terraform {
 
 provider "azurerm" {
   features {}
-  skip_provider_registration = true
-  use_oidc                   = true
+  use_oidc = true
 }
 
 provider "azapi" {

--- a/cluster-deployment/variables.tf
+++ b/cluster-deployment/variables.tf
@@ -92,3 +92,15 @@ variable "azure_object_id" {
   type        = string
   description = "The Azure Object ID of the user to grant Grafana admin rights"
 }
+
+variable "dapr_extension_name" {
+  type        = string
+  description = "The name of the Dapr extension"
+  default     = "dapr"
+}
+
+variable "dapr_extension_type" {
+  default     = "Microsoft.Dapr"
+  type        = string
+  description = "The type of the Dapr extension"
+}

--- a/modules/aks-extension/main.tf
+++ b/modules/aks-extension/main.tf
@@ -1,0 +1,7 @@
+resource "azurerm_kubernetes_cluster_extension" "ext" {
+  name = var.ext_name
+  cluster_id = var.cluster_id
+  extension_type = var.extension_type
+  release_train = "Stable"
+  configuration_settings = var.configuration_settings
+}

--- a/modules/aks-extension/variables.tf
+++ b/modules/aks-extension/variables.tf
@@ -1,0 +1,20 @@
+variable "ext_name" {
+  type = string
+  description = "The name of the AKS extension"
+}
+
+variable "cluster_id" {
+  type = string
+  description = "The ID of the AKS cluster to install the extension"
+}
+
+variable "extension_type" {
+  type = string
+  description = "The type of the extension"
+}
+
+variable "configuration_settings" {
+  type = map
+  description = "The configuration settings for the extension"
+  default = {}
+}


### PR DESCRIPTION
This pull request introduces a new Dapr extension module to the AKS cluster deployment and includes several related updates to the Terraform configuration files. The most important changes include adding the Dapr extension module, defining new variables for the extension, and creating the resource for the extension.

### Addition of Dapr Extension Module:
* [`cluster-deployment/main.tf`](diffhunk://#diff-d9ba3efc065737668ffc31e1aa2d07078b3f9e8b39d3f8a88ae9c93a8c4bcff2R92-R98): Added a new module `dapr-extension` for the Dapr extension with necessary variables such as `extension_type`, `cluster_id`, and `ext_name`.

### Variable Definitions:
* [`cluster-deployment/variables.tf`](diffhunk://#diff-70df426f15ccf37e0f0e49aee2c7bf902220e46e886f02465238520c67b5edc7R95-R106): Introduced new variables `dapr_extension_name` and `dapr_extension_type` to store the name and type of the Dapr extension, respectively.
* [`modules/aks-extension/variables.tf`](diffhunk://#diff-1931a5824993c1bce28a16fc3ba5c359708d465fe81138f51fb9e61bc0f94076R1-R20): Added variables `ext_name`, `cluster_id`, `extension_type`, and `configuration_settings` to configure the AKS extension.

### Resource Creation:
* [`modules/aks-extension/main.tf`](diffhunk://#diff-d97aad414f732b2abacadfe86a6a018edd5c158377bd4250b328cdeb2278c11dR1-R7): Created a new resource `azurerm_kubernetes_cluster_extension` to define the Dapr extension with properties like `name`, `cluster_id`, `extension_type`, and `configuration_settings`.

### Provider Configuration:
* [`cluster-deployment/providers.tf`](diffhunk://#diff-d224f945bd89d6bded0cb509dba9eadd1d23d13b8290bd1499878ccdf6a715adL31): Removed the `skip_provider_registration` property from the `azurerm` provider configuration.