### PR TITLE
Removing PR requirement for Terraform Plan

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -21,7 +21,6 @@ env:
 
 jobs:
   terraform-plan:
-    if: github.event_name == 'pull_request'
     defaults:
       run:
         working-directory: ./cluster-deployment

--- a/cluster-deployment/tfvars/terraform.tfvars
+++ b/cluster-deployment/tfvars/terraform.tfvars
@@ -3,6 +3,7 @@ location = "australiaeast"
 tags = {
   environment = "dev"
   owner = "willvelida"
+  application = "velidaaks"
 }
 user_assigned_identity_name = "dev-uai-velidaaks"
 acr_name = "devacrvelidaaks"


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/deploy-infra.yml` file to modify the conditions under which the `terraform-plan` job runs.

* [`.github/workflows/deploy-infra.yml`](diffhunk://#diff-4c19f571e78aef48c8dbd1f55a643094ff0688cbdafd9babb7962cf7443a5c2dL24): Removed the condition that restricted the `terraform-plan` job to only run on pull requests.