### PR TITLE
Adding sample apps. Enabling autoscaling on the cluster

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -1,8 +1,5 @@
 name: Deploy AKS Cluster Infra
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/apps/aks-basic/deployment.yaml
+++ b/apps/aks-basic/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment 
+metadata:
+  name: contoso-website
+spec:
+  selector:
+    matchLabels:
+      app: contoso-website
+  template:
+    metadata:
+      labels:
+        app: contoso-website
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: contoso-website
+          image: mcr.microsoft.com/mslearn/samples/contoso-website
+          ports:
+            - containerPort: 80
+              name: http
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi

--- a/apps/radius-basic/.rad/rad.yaml
+++ b/apps/radius-basic/.rad/rad.yaml
@@ -1,0 +1,2 @@
+workspace:
+  application: "radius-basic"

--- a/apps/radius-basic/app.bicep
+++ b/apps/radius-basic/app.bicep
@@ -1,0 +1,66 @@
+extension radius
+
+@description('The Radius Application ID. Injected automatically by the rad CLI.')
+param application string
+
+@description('The ID of the Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource demo 'Applications.Core/containers@2023-10-01-preview' = {
+  name: 'demo'
+  properties: {
+    application: application
+    container: {
+      image: 'ghcr.io/radius-project/samples/demo:latest'
+      ports: {
+        web: {
+          containerPort: 3000
+        }
+      }
+    }
+    connections: {
+      mongodb: {
+        source: mongodb.id
+      }
+      backend: {
+        source: 'http://backend:80'
+      }
+    }
+  }
+}
+
+resource backend 'Applications.Core/containers@2023-10-01-preview' = {
+  name: 'backend'
+  properties: {
+    application: application 
+    container: {
+      image: 'nginx:latest'
+      ports: {
+        api: {
+          containerPort: 80
+        }
+      }
+    }
+  }
+}
+
+resource mongodb 'Applications.Datastores/mongoDatabases@2023-10-01-preview' = {
+  name: 'mongodb'
+  properties: {
+    environment: environment
+    application: application
+  }
+}
+
+resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
+  name: 'gateway'
+  properties: {
+    application: application
+    routes: [
+      {
+        path: '/'
+        destination: 'http://demo:3000'
+      }
+    ]
+  }
+}

--- a/apps/radius-basic/bicepconfig.json
+++ b/apps/radius-basic/bicepconfig.json
@@ -1,0 +1,11 @@
+{
+	"experimentalFeaturesEnabled": {
+		"extensibility": true,
+		"extensionRegistry": true,
+		"dynamicTypeLoading": true
+	},
+	"extensions": {
+		"radius": "br:biceptypes.azurecr.io/radius:0.38",
+		"aws": "br:biceptypes.azurecr.io/aws:0.38"
+	}
+}

--- a/apps/radius-dapr/.rad/rad.yaml
+++ b/apps/radius-dapr/.rad/rad.yaml
@@ -1,0 +1,2 @@
+workspace:
+  application: "radius-dapr"

--- a/apps/radius-dapr/app.bicep
+++ b/apps/radius-dapr/app.bicep
@@ -1,0 +1,81 @@
+extension radius
+
+@description('Specifies the environment for resources.')
+param environment string
+
+@description('The ID of your Radius Application. Automatically injected by the rad CLI.')
+param application string
+
+// The backend container that is connected to the Dapr state store
+resource backend 'Applications.Core/containers@2023-10-01-preview' = {
+  name: 'backend'
+  properties: {
+    application: application
+    container: {
+      // This image is where the app's backend code lives
+      image: 'ghcr.io/radius-project/samples/dapr-backend:latest'
+      ports: {
+        orders: {
+          containerPort: 3000
+        }
+      }
+    }
+    connections: {
+      orders: {
+        source: stateStore.id
+      }
+    }
+    extensions: [
+      {
+        kind: 'daprSidecar'
+        appId: 'backend'
+        appPort: 3000
+      }
+    ]
+  }
+}
+
+// The frontend container that serves the application UI
+resource frontend 'Applications.Core/containers@2023-10-01-preview' = {
+  name: 'frontend'
+  properties: {
+    application: application
+    container: {
+      // This image is where the app's frontend code lives
+      image: 'ghcr.io/radius-project/samples/dapr-frontend:latest'
+      env: {
+        // An environment variable to tell the frontend container where to find the backend
+        CONNECTION_BACKEND_APPID: {
+          value: 'backend'
+        }
+        // An environment variable to override the default port that .NET Core listens on
+        ASPNETCORE_URLS: {
+          value: 'http://*:8080'
+        }
+      }
+      // The frontend container exposes port 8080, which is used to serve the UI
+      ports: {
+        ui: {
+          containerPort: 8080
+        }
+      }
+    }
+    // The extension to configure Dapr on the container, which is used to invoke the backend
+    extensions: [
+      {
+        kind: 'daprSidecar'
+        appId: 'frontend'
+      }
+    ]
+  }
+}
+
+// The Dapr state store that is connected to the backend container
+resource stateStore 'Applications.Dapr/stateStores@2023-10-01-preview' = {
+  name: 'statestore'
+  properties: {
+    // Provision Redis Dapr state store automatically via the default Radius Recipe
+    environment: environment
+    application: application
+  }
+}

--- a/apps/radius-dapr/bicepconfig.json
+++ b/apps/radius-dapr/bicepconfig.json
@@ -1,0 +1,11 @@
+{
+	"experimentalFeaturesEnabled": {
+		"extensibility": true,
+		"extensionRegistry": true,
+		"dynamicTypeLoading": true
+	},
+	"extensions": {
+		"radius": "br:biceptypes.azurecr.io/radius:0.38",
+		"aws": "br:biceptypes.azurecr.io/aws:0.38"
+	}
+}

--- a/cluster-deployment/main.tf
+++ b/cluster-deployment/main.tf
@@ -87,6 +87,8 @@ module "aks" {
   node_count     = var.node_count
   identity_ids   = module.user_assigned_identity.user_assinged_identity_id
   aks_name       = var.aks_name
+  min_count      = var.min_count
+  max_count      = var.max_count
 }
 
 module "dapr-extension" {

--- a/cluster-deployment/variables.tf
+++ b/cluster-deployment/variables.tf
@@ -104,3 +104,15 @@ variable "dapr_extension_type" {
   type        = string
   description = "The type of the Dapr extension"
 }
+
+variable "min_count" {
+  type        = number
+  description = "The minimum number of nodes in the AKS cluster"
+  default     = 1
+}
+
+variable "max_count" {
+  type        = number
+  description = "The maximum number of nodes in the AKS cluster"
+  default     = 5
+}

--- a/modules/aks-cluster/main.tf
+++ b/modules/aks-cluster/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     name = "default"
     node_count = var.node_count
     vm_size = var.vm_size
-    auto_scaling_enabled = true
+    enable_auto_scaling = true
     type = "VirtualMachineScaleSets"
     min_count = var.min_count
     max_count = var.max_count
@@ -36,5 +36,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
     ssh_key {
       key_data = var.ssh_public_key
     }
+  }
+
+  lifecycle {
+    ignore_changes = [default_node_pool[0].node_count]
   }
 }

--- a/modules/aks-cluster/main.tf
+++ b/modules/aks-cluster/main.tf
@@ -10,6 +10,10 @@ resource "azurerm_kubernetes_cluster" "aks" {
     name = "default"
     node_count = var.node_count
     vm_size = var.vm_size
+    auto_scaling_enabled = true
+    type = "VirtualMachineScaleSets"
+    min_count = var.min_count
+    max_count = var.max_count
   }
 
   identity {

--- a/modules/aks-cluster/variables.tf
+++ b/modules/aks-cluster/variables.tf
@@ -41,3 +41,13 @@ variable "username" {
 variable "ssh_public_key" {
   description = "The SSH public key to use for the AKS cluster"
 }
+
+variable "min_count" {
+  description = "The minimum number of nodes in the AKS cluster"
+  type = number
+}
+
+variable "max_count" {
+  description = "The maximum number of nodes in the AKS cluster"
+  type = number
+}


### PR DESCRIPTION
This pull request includes several changes across multiple files to enhance the configuration and deployment of AKS clusters and integrate Radius and Dapr applications. The most important changes involve updating deployment configurations, adding new resource definitions, and enabling experimental features.

### Deployment Configuration Updates

* [`.github/workflows/deploy-infra.yml`](diffhunk://#diff-4c19f571e78aef48c8dbd1f55a643094ff0688cbdafd9babb7962cf7443a5c2dL3-L5): Modified the workflow to trigger on pull requests to the `main` branch instead of pushes.
* [`cluster-deployment/main.tf`](diffhunk://#diff-d9ba3efc065737668ffc31e1aa2d07078b3f9e8b39d3f8a88ae9c93a8c4bcff2R90-R91): Added `min_count` and `max_count` variables to the AKS module to support autoscaling.
* [`cluster-deployment/variables.tf`](diffhunk://#diff-70df426f15ccf37e0f0e49aee2c7bf902220e46e886f02465238520c67b5edc7R107-R118): Introduced `min_count` and `max_count` variables with default values to configure the minimum and maximum number of nodes in the AKS cluster.
* [`modules/aks-cluster/main.tf`](diffhunk://#diff-65d3ca75e64fa03879571b3f26a2c1e9b0d0673f83ba1d0ccac93eb3ceaa1bb0R13-R16): Enabled autoscaling and set the `type` to `VirtualMachineScaleSets` for the AKS cluster.
* [`modules/aks-cluster/variables.tf`](diffhunk://#diff-9a799618270f3832b91d4c8413ef58614e80275f9e63df37170f7bdb736ec65bR44-R53): Added `min_count` and `max_count` variables to support autoscaling configuration.

### Resource Definitions for Radius Applications

* [`apps/radius-basic/app.bicep`](diffhunk://#diff-1b40a90c03c6a3480da7e31842ac2473655cce022180434391899266135f244bR1-R66): Added resource definitions for `demo`, `backend`, `mongodb`, and `gateway` containers, specifying their properties and connections.
* [`apps/radius-basic/.rad/rad.yaml`](diffhunk://#diff-7668bb6f19858a3424c88abbeb2e61c50f84c7b9ff601f6398880e0294d44a12R1-R2): Defined the workspace for the `radius-basic` application.
* [`apps/radius-basic/bicepconfig.json`](diffhunk://#diff-0dd96c3334cc0a69830339b67335bdf8d4de0068e92f8e36e2aee216ac284e69R1-R11): Enabled experimental features and added extensions for Radius and AWS.

### Resource Definitions for Dapr Applications

* [`apps/radius-dapr/app.bicep`](diffhunk://#diff-aed5a9dccec9a8e2f86e79588df93b22eeb486089a9cdd40e68a7bcd4345122bR1-R81): Added resource definitions for `backend`, `frontend`, and `stateStore` containers, including Dapr sidecar configurations and environment variables.
* [`apps/radius-dapr/.rad/rad.yaml`](diffhunk://#diff-f0e658b87987cc5836f182ec6b8e11afc25cdb1e40307e0ac566ffd6bdfe675dR1-R2): Defined the workspace for the `radius-dapr` application.
* [`apps/radius-dapr/bicepconfig.json`](diffhunk://#diff-0dd96c3334cc0a69830339b67335bdf8d4de0068e92f8e36e2aee216ac284e69R1-R11): Enabled experimental features and added extensions for Radius and AWS.

### AKS Deployment

* [`apps/aks-basic/deployment.yaml`](diffhunk://#diff-5e481d9573b292fb434403b86eb12ac9d45e22f9539994bff5ce24a46516f45dR1-R28): Added a new deployment configuration for the `contoso-website` application, specifying the container image, ports, and resource requests/limits.