### PR TITLE
Enabling KEDA autoscaler in TF module

### DIFF
--- a/modules/aks-cluster/main.tf
+++ b/modules/aks-cluster/main.tf
@@ -16,6 +16,10 @@ resource "azurerm_kubernetes_cluster" "aks" {
     max_count = var.max_count
   }
 
+  workload_autoscaler_profile {
+    keda_enabled = true
+  }
+
   identity {
     type = "UserAssigned"
     identity_ids = [ var.identity_ids ]


### PR DESCRIPTION
This pull request includes a small but important change to the `modules/aks-cluster/main.tf` file. The change enables the Kubernetes Event-Driven Autoscaler (KEDA) in the AKS cluster configuration.

* [`modules/aks-cluster/main.tf`](diffhunk://#diff-65d3ca75e64fa03879571b3f26a2c1e9b0d0673f83ba1d0ccac93eb3ceaa1bb0R19-R22): Added a `workload_autoscaler_profile` block to enable KEDA in the AKS cluster configuration.