### PR TITLE
Enabling Cost Analysis add-on on cluster

### DIFF
--- a/modules/aks-cluster/main.tf
+++ b/modules/aks-cluster/main.tf
@@ -5,6 +5,8 @@ resource "azurerm_kubernetes_cluster" "aks" {
   dns_prefix = var.aks_name
   role_based_access_control_enabled = true
   tags = var.tags
+  cost_analysis_enabled = true
+  sku_tier = "Standard"
 
   default_node_pool {
     name = "default"


### PR DESCRIPTION
This pull request includes changes to the `modules/aks-cluster/main.tf` file to enhance the configuration of the Azure Kubernetes Service (AKS) cluster. The most important changes involve enabling cost analysis and setting the SKU tier to "Standard".

Enhancements to AKS configuration:

* [`modules/aks-cluster/main.tf`](diffhunk://#diff-65d3ca75e64fa03879571b3f26a2c1e9b0d0673f83ba1d0ccac93eb3ceaa1bb0R8-R9): Enabled cost analysis for better cost management and visibility. (`cost_analysis_enabled = true`)
* [`modules/aks-cluster/main.tf`](diffhunk://#diff-65d3ca75e64fa03879571b3f26a2c1e9b0d0673f83ba1d0ccac93eb3ceaa1bb0R8-R9): Set the SKU tier to "Standard" to ensure a higher level of service. (`sku_tier = "Standard"`)