### PR TITLE
Adding concepts folder

### DIFF
--- a/cluster-deployment/tfvars/terraform.tfvars
+++ b/cluster-deployment/tfvars/terraform.tfvars
@@ -4,6 +4,7 @@ tags = {
   environment = "dev"
   owner = "willvelida"
   application = "velidaaks"
+  location = "australiaeast"
 }
 user_assigned_identity_name = "dev-uai-velidaaks"
 acr_name = "devacrvelidaaks"

--- a/concepts/pods/initpod.yml
+++ b/concepts/pods/initpod.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: initpod
+  labels:
+    name: initpod
+    app: initializer
+spec:
+  initContainers:
+  - name: initpod
+    image: busybox:1.28.4
+    command : ['sh', '-c', 'until nslookup k8sbook; do echo waiting for k8sbook service;sleep 1; done; echo Service found!']
+
+  containers:
+  - name: web-ctr
+    image: nigelpoulton/web-app:1.0
+    ports:
+      - containerPort: 8080

--- a/concepts/pods/initsvc.yml
+++ b/concepts/pods/initsvc.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8sbook
+spec:
+  selector:
+    app: initializer
+  ports:
+  - port: 80
+    targetPort: 8080
+  type: ClusterIP

--- a/concepts/pods/pod.yml
+++ b/concepts/pods/pod.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello-pod
+  labels:
+    name: hello-pod
+    zone: prod
+    version: v1
+spec:
+  containers:
+  - name: hello-pod
+    image: nigelpoulton/k8sbook:1.0
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    ports:
+      - containerPort: 8080

--- a/modules/aks-cluster/main.tf
+++ b/modules/aks-cluster/main.tf
@@ -11,6 +11,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     node_count = var.node_count
     vm_size = var.vm_size
     type = "VirtualMachineScaleSets"
+    auto_scaling_enabled = true
     min_count = var.min_count
     max_count = var.max_count
   }

--- a/modules/aks-cluster/main.tf
+++ b/modules/aks-cluster/main.tf
@@ -10,8 +10,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
     name = "default"
     node_count = var.node_count
     vm_size = var.vm_size
+    enable_auto_scaling = true
     type = "VirtualMachineScaleSets"
-    auto_scaling_enabled = true
+    
     min_count = var.min_count
     max_count = var.max_count
   }


### PR DESCRIPTION
This pull request introduces a new Kubernetes Pod configuration file `pod.yml` that defines a simple Pod setup.

* [`concepts/pods/pod.yml`](diffhunk://#diff-c61c0a714fbf5beb632cb160e25f7252a09e7ec92e815b6853421946a4446ff3R1-R18): Added a new Pod configuration with metadata and specifications for a container running the `nigelpoulton/k8sbook:1.0` image, including resource limits and port configuration.