### PR TITLE
Feature/k8sbook pods

### DIFF
--- a/cluster-deployment/tfvars/terraform.tfvars
+++ b/cluster-deployment/tfvars/terraform.tfvars
@@ -4,6 +4,7 @@ tags = {
   environment = "dev"
   owner = "willvelida"
   application = "velidaaks"
+  location = "australiaeast"
 }
 user_assigned_identity_name = "dev-uai-velidaaks"
 acr_name = "devacrvelidaaks"

--- a/concepts/deployments/deploy.yml
+++ b/concepts/deployments/deploy.yml
@@ -1,0 +1,31 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: hello-deploy
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: hello-world
+  revisionHistoryLimit: 5
+  progressDeadlineSeconds: 300
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: hello-world
+    spec:
+      containers:
+        - name: hello-pod
+          image: nigelpoulton/k8sbook:2.0
+          ports:
+          - containerPort: 8080
+          resources:
+            limits:
+              memory: 128Mi
+              cpu: "0.1"

--- a/concepts/deployments/loadBalancer.yml
+++ b/concepts/deployments/loadBalancer.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: lb-svc
+  labels:
+    app: hello-world
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8080
+    protocol: TCP
+  selector:
+    app: hello-world

--- a/concepts/namespaces/app.yml
+++ b/concepts/namespaces/app.yml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: shield
+  name: default
+---
+apiVersion: v1
+kind: Service 
+metadata:
+  namespace: shield
+  name: the-bus
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8080
+    targetPort: 8080
+  selector:
+    env: marvel
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: shield
+  name: triskelion
+  labels:
+    env: marvel
+spec:
+  containers:
+  - image: nigelpoulton/k8sbook:shield-01
+    name: bus-ctr
+    ports:
+    - containerPort: 8080
+    imagePullPolicy: Always

--- a/concepts/namespaces/shield-ns.yml
+++ b/concepts/namespaces/shield-ns.yml
@@ -1,0 +1,6 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: shield
+  labels:
+    env: marvel

--- a/concepts/pods/initpod.yml
+++ b/concepts/pods/initpod.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: initpod
+  labels:
+    name: initpod
+    app: initializer
+spec:
+  initContainers:
+  - name: initpod
+    image: busybox:1.28.4
+    command : ['sh', '-c', 'until nslookup k8sbook; do echo waiting for k8sbook service;sleep 1; done; echo Service found!']
+
+  containers:
+  - name: web-ctr
+    image: nigelpoulton/web-app:1.0
+    ports:
+      - containerPort: 8080

--- a/concepts/pods/initsvc.yml
+++ b/concepts/pods/initsvc.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8sbook
+spec:
+  selector:
+    app: initializer
+  ports:
+  - port: 80
+    targetPort: 8080
+  type: ClusterIP

--- a/concepts/pods/pod.yml
+++ b/concepts/pods/pod.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello-pod
+  labels:
+    name: hello-pod
+    zone: prod
+    version: v1
+spec:
+  containers:
+  - name: hello-pod
+    image: nigelpoulton/k8sbook:1.0
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    ports:
+      - containerPort: 8080

--- a/modules/aks-cluster/main.tf
+++ b/modules/aks-cluster/main.tf
@@ -17,6 +17,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
     max_count = var.max_count
   }
 
+  oidc_issuer_enabled = true
+  workload_identity_enabled = true
+
   workload_autoscaler_profile {
     keda_enabled = true
   }

--- a/modules/aks-cluster/main.tf
+++ b/modules/aks-cluster/main.tf
@@ -11,6 +11,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     node_count = var.node_count
     vm_size = var.vm_size
     type = "VirtualMachineScaleSets"
+    auto_scaling_enabled = true
     min_count = var.min_count
     max_count = var.max_count
   }

--- a/modules/aks-cluster/main.tf
+++ b/modules/aks-cluster/main.tf
@@ -10,8 +10,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
     name = "default"
     node_count = var.node_count
     vm_size = var.vm_size
+    enable_auto_scaling = true
     type = "VirtualMachineScaleSets"
-    auto_scaling_enabled = true
+    
     min_count = var.min_count
     max_count = var.max_count
   }


### PR DESCRIPTION
This pull request includes multiple changes to various Kubernetes configuration files, as well as updates to Terraform variables for cluster deployment. The most important changes include adding a new location tag in the Terraform variables, defining new Kubernetes resources such as Deployments, Services, and Namespaces, and enabling auto-scaling and workload identity in the AKS cluster configuration.

### Kubernetes Configuration Changes:

* [`concepts/deployments/deploy.yml`](diffhunk://#diff-fcfb985619771550e1e022d489c76f3440f552434231b04377d9c62f107351ffR1-R31): Added a new Deployment configuration for `hello-deploy` with 10 replicas and a rolling update strategy.
* [`concepts/deployments/loadBalancer.yml`](diffhunk://#diff-050525d38eeaa4c62fca2f772a63960552c4353966dae4eb1ef13850b2ca78d9R1-R13): Added a new LoadBalancer Service configuration for `lb-svc` targeting port 8080.
* [`concepts/namespaces/app.yml`](diffhunk://#diff-390d3ff08288d3ae1e2680ad8c6fe1e55fc4bfc1664fd3e66cffddb80157b0d9R1-R33): Added configurations for a ServiceAccount, LoadBalancer Service, and Pod within the `shield` namespace.
* [`concepts/namespaces/shield-ns.yml`](diffhunk://#diff-f7876dcb9b53e02b4c9961ad3244eb292201c40327ff144b1b84a135cbf5216eR1-R6): Added a new Namespace configuration for `shield` with the label `env: marvel`.
* [`concepts/pods/initpod.yml`](diffhunk://#diff-d59c8640f0a037579d5314b8a0f398ef088a5c126d1131581424df4b7d434a1cR1-R18): Added a new Pod configuration for `initpod` with an init container that waits for the `k8sbook` service.
* [`concepts/pods/initsvc.yml`](diffhunk://#diff-fbdb1fdee309bea9554c43847b6a55d30cdebc7861e5930e76f23542f685a0b5R1-R11): Added a new ClusterIP Service configuration for `k8sbook` targeting port 80.
* [`concepts/pods/pod.yml`](diffhunk://#diff-c61c0a714fbf5beb632cb160e25f7252a09e7ec92e815b6853421946a4446ff3R1-R18): Added a new Pod configuration for `hello-pod` with resource limits and a container port of 8080.

### Terraform Configuration Changes:

* [`cluster-deployment/tfvars/terraform.tfvars`](diffhunk://#diff-da175d395e2318e59c1e8d3e4b341c7e3a268954c8831e696ab6a402a8d66c3dR7): Added a new location tag with the value `australiaeast`.
* [`modules/aks-cluster/main.tf`](diffhunk://#diff-65d3ca75e64fa03879571b3f26a2c1e9b0d0673f83ba1d0ccac93eb3ceaa1bb0R13-R22): Enabled auto-scaling, workload identity, and OIDC issuer in the AKS cluster configuration.