### PR TITLE
Adding AKS Azure Policy manifests

### DIFF
--- a/apps/aks-azure-policy/web-app-privileged.yml
+++ b/apps/aks-azure-policy/web-app-privileged.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web-app-privileged
+spec:
+  containers:
+  - name: web-app-privileged
+    image: willvelida/hello-web-app:1.0.0
+    securityContext:
+      privileged: true
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    ports:
+      - containerPort: 3000

--- a/apps/aks-azure-policy/web-app.yml
+++ b/apps/aks-azure-policy/web-app.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web-app
+spec:
+  containers:
+  - name: web-app
+    image: willvelida/hello-web-app:1.0.0
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    ports:
+      - containerPort: 3000


### PR DESCRIPTION
This pull request introduces new Kubernetes pod definitions for a web application, including both a privileged and a non-privileged version. 

New Kubernetes pod definitions:

* [`apps/aks-azure-policy/web-app-privileged.yml`](diffhunk://#diff-5c861a93ce4c3febcde19bff6306e18f7ec45c570235cc5a39cf6f9ce78231b8R1-R16): Added a new pod definition for a privileged web application container with specific resource limits and security context settings.
* [`apps/aks-azure-policy/web-app.yml`](diffhunk://#diff-9011608650f4f2ffdcbfe846cc6a892ed93d83df378d7024143d35f23104cbb5R1-R14): Added a new pod definition for a standard web application container with specific resource limits.